### PR TITLE
Release 1.0.8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A powerful fluent API for testing Flogger log statements, and more.
 <dependency>
     <groupId>net.goui.flogger-testing</groupId>
     <artifactId>junit4</artifactId>  <!-- or "junit5" -->
-    <version>1.0.5</version>
+    <version>1.0.8</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -21,7 +21,7 @@ And if you are using `Log4J2`:
 <dependency>
     <groupId>net.goui.flogger-testing</groupId>
     <artifactId>log4j</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.8</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,12 +17,12 @@
     <parent>
         <groupId>net.goui.flogger-testing</groupId>
         <artifactId>flogger-testing</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
     </parent>
 
     <artifactId>api</artifactId>
     <name>Flogger Testing API</name>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <packaging>jar</packaging>
     <url>${base.url}/${project.artifactId}</url>
 

--- a/api/src/main/java/net/goui/flogger/testing/jdk/JdkInterceptor.java
+++ b/api/src/main/java/net/goui/flogger/testing/jdk/JdkInterceptor.java
@@ -65,8 +65,9 @@ public final class JdkInterceptor implements LogInterceptor {
     Level jdkLogLevel = level.toJdkLogLevel();
     handler.setLevel(jdkLogLevel);
     Logger jdkLogger = Logger.getLogger(loggerName);
+    // The old level can be null (implying it's inherited) but isLoggable() does the right thing.
     Level oldJdkLevel = jdkLogger.getLevel();
-    if (jdkLogLevel.intValue() < oldJdkLevel.intValue()) {
+    if (!jdkLogger.isLoggable(jdkLogLevel)) {
       jdkLogger.setLevel(jdkLogLevel);
     }
     jdkLogger.addHandler(handler);

--- a/api/src/main/java/net/goui/flogger/testing/truth/LogFilters.java
+++ b/api/src/main/java/net/goui/flogger/testing/truth/LogFilters.java
@@ -28,7 +28,7 @@ final class LogFilters {
 
   private static int offsetOfFragment(String message, String fragment, int offset) {
     checkArgument(!fragment.isEmpty(), "message fragments must not be empty");
-    if (offset >= -1) {
+    if (offset != -1) {
       int start = message.indexOf(fragment, offset);
       offset = start >= 0 ? start + fragment.length() : -1;
     }

--- a/api/src/test/java/net/goui/flogger/testing/truth/LogFiltersTest.java
+++ b/api/src/test/java/net/goui/flogger/testing/truth/LogFiltersTest.java
@@ -27,6 +27,7 @@ public class LogFiltersTest extends TestCase {
     assertThat(containsAllFragmentsInOrder("hello world", "hello")).isTrue();
     assertThat(containsAllFragmentsInOrder("hello world", "hello", "world")).isTrue();
 
+    assertThat(containsAllFragmentsInOrder("hello world", "goodbye", "world")).isFalse();
     assertThat(containsAllFragmentsInOrder("hello world", "world", "hello")).isFalse();
     assertThat(containsAllFragmentsInOrder("hello world", "hello", "hello")).isFalse();
 

--- a/junit4/pom.xml
+++ b/junit4/pom.xml
@@ -17,12 +17,12 @@
     <parent>
         <groupId>net.goui.flogger-testing</groupId>
         <artifactId>flogger-testing</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
     </parent>
 
     <artifactId>junit4</artifactId>
     <name>Flogger Junit4 Test Harness</name>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <packaging>jar</packaging>
     <url>${base.url}/${project.artifactId}</url>
 
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>net.goui.flogger-testing</groupId>
             <artifactId>api</artifactId>
-            <version>1.0.7</version>
+            <version>1.0.8</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>

--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -17,12 +17,12 @@
     <parent>
         <groupId>net.goui.flogger-testing</groupId>
         <artifactId>flogger-testing</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
     </parent>
 
     <artifactId>junit5</artifactId>
     <name>Flogger Junit5 Test Harness</name>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <packaging>jar</packaging>
     <url>${base.url}/${project.artifactId}</url>
 
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>net.goui.flogger-testing</groupId>
             <artifactId>api</artifactId>
-            <version>1.0.7</version>
+            <version>1.0.8</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
         <dependency>

--- a/log4j2/pom.xml
+++ b/log4j2/pom.xml
@@ -76,7 +76,7 @@
                     <groupId>com.google.flogger</groupId>
                     <artifactId>flogger-grpc-context</artifactId>
                     <version>0.7.4</version>
-                    <scope>test</scope>
+                    <scope>runtime</scope>
                 </dependency>
             </dependencies>
         </profile>

--- a/log4j2/pom.xml
+++ b/log4j2/pom.xml
@@ -18,12 +18,12 @@
     <parent>
         <groupId>net.goui.flogger-testing</groupId>
         <artifactId>flogger-testing</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
     </parent>
 
     <artifactId>log4j</artifactId>
     <name>Flogger Log4j2 Test Integration</name>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <packaging>jar</packaging>
     <url>${base.url}/${project.artifactId}</url>
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>net.goui.flogger-testing</groupId>
             <artifactId>api</artifactId>
-            <version>1.0.7</version>
+            <version>1.0.8</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
         <dependency>
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>net.goui.flogger-testing</groupId>
             <artifactId>junit4</artifactId>
-            <version>1.0.7</version>
+            <version>1.0.8</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <artifactId>flogger-testing</artifactId>
     <name>Flogger Testing API</name>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <packaging>pom</packaging>
     <url>https://github.com/hagbard/flogger-testing</url>
 


### PR DESCRIPTION
* Fixed NullPointerException in JDK interceptor when the log level was not explicitly set on the target logger.
* Made gRPC dependency "runtime" (possibly more examples of this but it's not urgent).
* Fixed typo in LogFilter (was allowing false positives).
* Bump version to 1.0.8.